### PR TITLE
Added codecov support

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const parsersKeys = Object.keys(parsers);
 // codacy https://api.codacy.com/project/badge/grade/${hash}
 // gitter https://badges.gitter.im/${user}/${package}.png
 // parallelci
-// https://codecov.io/github/codecov/codecov-ruby/coverage.svg?branch=master
 // http://www.coverity.com/
 
 // loose definition of a badge url

--- a/lib/codecov.js
+++ b/lib/codecov.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// https://codecov.io/${service}/${user}/${repo}/coverage.svg
+// https://codecov.io/${service}/${user}/${repo}/coverage.svg?branch=${branch}
+// https://codecov.io/${service}/${user}/${repo}/branch/${branch}/coverage.svg
+// https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg
+// https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg?branch=${branch}
+// https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg
+// https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg
+// https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg
+
+module.exports = function (parsedUrl) {
+    const url = parsedUrl.href.split('?')[0];
+    let match;
+    let data;
+
+    if ((match = url.match(/img.shields.io\/codecov\/c\/(.+)\/(.+)\/(.+)\/(.+)\..+/))) {
+        // shields badge with branch
+        data = { service: match[1], user: match[2], repo: match[3], branch: match[4] };
+    } else if ((match = url.match(/img.shields.io\/codecov\/c\/(.+)\/(.+)\/(.+)\..+/))) {
+        // shields badge
+        data = { service: match[1], user: match[2], repo: match[3] };
+    } else if ((match = url.match(/codecov.io\/(.+)\/(.+)\/(.+)\/branch\/(.+)\/(coverage|graphs\/badge)\..+/))) {
+        // codecov badge with branch url
+        data = { service: match[1], user: match[2], repo: match[3], branch: match[4] };
+    } else if ((match = url.match(/codecov.io\/(.+)\/(.+)\/(.+)\/(coverage|graphs\/badge)\..+/))) {
+        // codecov badge with branch in query
+        data = { service: match[1], user: match[2], repo: match[3], branch: parsedUrl.query.branch };
+    } else {
+        return null;
+    }
+
+    const codecovUrl = 'https://codecov.io/' +
+        `${data.service}/${data.user}/${data.repo}/${data.branch ? `branch/${data.branch}/` : ''}graphs/badge.svg`;
+    const shieldsUrl =
+        `https://img.shields.io/codecov/c/${data.service}/${data.user}/${data.repo}${data.branch ? `/${data.branch}` : ''}`;
+
+    return {
+        urls: {
+            original: parsedUrl.href,
+            service: codecovUrl,
+            shields: `${shieldsUrl}.svg`,
+            content: `${shieldsUrl}.json`,
+        },
+        info: {
+            service: 'codecov',
+            type: 'coverage',
+            modifiers: data.branch ? { branch: data.branch } : {},
+        },
+    };
+};

--- a/test/spec/codecov.js
+++ b/test/spec/codecov.js
@@ -1,0 +1,106 @@
+import test from 'ava';
+import detectBadges from '../../';
+
+test('codecov: codecov.io old style', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+
+    const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/coverage.svg`)[0];
+
+    t.is(badge.urls.original, `https://codecov.io/${service}/${user}/${repo}/coverage.svg`);
+    t.is(badge.urls.service, `https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg`);
+    t.is(badge.urls.shields, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg`);
+    t.is(badge.urls.content, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.json`);
+    t.is(badge.info.service, 'codecov');
+    t.is(badge.info.type, 'coverage');
+});
+
+test('codecov: codecov.io old style (with branch)', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/coverage.svg?branch=${branch}`)[0];
+
+    t.is(badge.urls.original, `https://codecov.io/${service}/${user}/${repo}/coverage.svg?branch=${branch}`);
+    t.is(badge.urls.service, `https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg`);
+    t.is(badge.urls.shields, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg`);
+    t.is(badge.urls.content, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.json`);
+    t.is(badge.info.service, 'codecov');
+    t.is(badge.info.type, 'coverage');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codecov: codecov.io new style', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+
+    const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg`)[0];
+
+    t.is(badge.urls.original, `https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg`);
+    t.is(badge.urls.service, `https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg`);
+    t.is(badge.urls.shields, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg`);
+    t.is(badge.urls.content, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.json`);
+    t.is(badge.info.service, 'codecov');
+    t.is(badge.info.type, 'coverage');
+});
+
+test('codecov: codecov.io new style (with branch)', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg`)[0];
+
+    t.is(badge.urls.original, `https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg`);
+    t.is(badge.urls.service, `https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg`);
+    t.is(badge.urls.shields, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg`);
+    t.is(badge.urls.content, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.json`);
+    t.is(badge.info.service, 'codecov');
+    t.is(badge.info.type, 'coverage');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codecov: shields.io', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+
+    const badge = detectBadges(`https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg`)[0];
+
+    t.is(badge.urls.original, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg`);
+    t.is(badge.urls.service, `https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg`);
+    t.is(badge.urls.shields, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg`);
+    t.is(badge.urls.content, `https://img.shields.io/codecov/c/${service}/${user}/${repo}.json`);
+    t.is(badge.info.service, 'codecov');
+    t.is(badge.info.type, 'coverage');
+});
+
+test('codecov: shields.io (with branch)', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg`)[0];
+
+    t.is(badge.urls.original, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg`);
+    t.is(badge.urls.service, `https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg`);
+    t.is(badge.urls.shields, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg`);
+    t.is(badge.urls.content, `https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.json`);
+    t.is(badge.info.service, 'codecov');
+    t.is(badge.info.type, 'coverage');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codecov: not a valid codecov url', t => {
+    const service = 'github';
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+
+    t.falsy(detectBadges(`https://codecov.com/${service}/${user}/${repo}/graph/coverage.svg`)[0]);
+});

--- a/test/spec/codecov.js
+++ b/test/spec/codecov.js
@@ -3,8 +3,8 @@ import detectBadges from '../../';
 
 test('codecov: codecov.io old style', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
 
     const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/coverage.svg`)[0];
 
@@ -18,8 +18,8 @@ test('codecov: codecov.io old style', t => {
 
 test('codecov: codecov.io old style (with branch)', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
     const branch = 'master';
 
     const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/coverage.svg?branch=${branch}`)[0];
@@ -35,8 +35,8 @@ test('codecov: codecov.io old style (with branch)', t => {
 
 test('codecov: codecov.io new style', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
 
     const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/graphs/badge.svg`)[0];
 
@@ -50,8 +50,8 @@ test('codecov: codecov.io new style', t => {
 
 test('codecov: codecov.io new style (with branch)', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
     const branch = 'master';
 
     const badge = detectBadges(`https://codecov.io/${service}/${user}/${repo}/branch/${branch}/graphs/badge.svg`)[0];
@@ -67,8 +67,8 @@ test('codecov: codecov.io new style (with branch)', t => {
 
 test('codecov: shields.io', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
 
     const badge = detectBadges(`https://img.shields.io/codecov/c/${service}/${user}/${repo}.svg`)[0];
 
@@ -82,8 +82,8 @@ test('codecov: shields.io', t => {
 
 test('codecov: shields.io (with branch)', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
     const branch = 'master';
 
     const badge = detectBadges(`https://img.shields.io/codecov/c/${service}/${user}/${repo}/${branch}.svg`)[0];
@@ -99,8 +99,8 @@ test('codecov: shields.io (with branch)', t => {
 
 test('codecov: not a valid codecov url', t => {
     const service = 'github';
-    const user = 'IndigoUnited';
-    const repo = 'js-promtie';
+    const user = 'codecov';
+    const repo = 'codecov-node';
 
     t.falsy(detectBadges(`https://codecov.com/${service}/${user}/${repo}/graph/coverage.svg`)[0]);
 });


### PR DESCRIPTION
Added support for [Codecov](https://codecov.io/) coverage badges and removed the corresponding TODO from `index.js`.

Supports both old and new style of codecov badges (at some point, documentation changed from `/coverage.svg` to `graphs/badge.svg`, the former now being redirected to the new one), includes tests for both those styles.