### PR TITLE
Add codacy support

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,12 @@ const parsers = requireDirectory(module, './lib', { recurse: false });
 const parsersKeys = Object.keys(parsers);
 
 // TODO badges to support:
-// codacy https://api.codacy.com/project/badge/grade/${hash}
 // gitter https://badges.gitter.im/${user}/${package}.png
 // parallelci
 // http://www.coverity.com/
 
 // Loose definition of a badge url
-// Appveyor is the only that doesn't have any extension. It has /api on the url,
+// Appveyor is the only that doesn't have any extension or badge on the url. It has /api on the url,
 // but this is too generic to be added here, so we playing safe and not applying it.
 function isBadgeUrl(url) {
     return ['.svg', '.png', '.jpg', '.gif', 'svg=true', 'png=true', 'badge', 'appveyor']

--- a/lib/codacy.js
+++ b/lib/codacy.js
@@ -5,13 +5,12 @@
 // https://api.codacy.com/project/badge/Coverage/${token}?branch=${branch}
 // https://img.shields.io/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg
 
+const capitalize = require('./util/capitalize');
+
 module.exports = function (parsedUrl) {
     const url = parsedUrl.href.split('?')[0];
     let match;
     let data;
-
-    const upperCaseFirstLetter = str => `${str.charAt(0).toUpperCase()}${str.substr(1)}`;
-
 
     if ((match = url.match(/img.shields.io\/codacy\/(.+)\/(.+)\/(.+).svg/))) {
         data = { type: match[1], token: match[2], branch: match[3] };
@@ -23,9 +22,13 @@ module.exports = function (parsedUrl) {
         return null;
     }
 
-    const codacyUrl = `https://api.codacy.com/project/badge/${upperCaseFirstLetter(data.type)}/${data.token}${data.branch ? `?branch=${data.branch}` : ''}`;
+    const codacyUrl = `https://api.codacy.com/project/badge/${capitalize(data.type)}/${data.token}${data.branch ? `?branch=${data.branch}` : ''}`;
     const shieldsUrl =
         `https://img.shields.io/codacy/${data.type}/${data.token}${data.branch ? `/${data.branch}` : ''}`;
+
+    if (data.type === 'grade') {
+        data.type = 'quality';
+    }
 
     return {
         urls: {

--- a/lib/codacy.js
+++ b/lib/codacy.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}
+// https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686/master.svg
+// https://api.codacy.com/project/badge/Coverage/${token}?branch=${branch}
+// https://img.shields.io/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg
+
+module.exports = function (parsedUrl) {
+    const url = parsedUrl.href.split('?')[0];
+    let match;
+    let data;
+
+    const upperCaseFirstLetter = str => `${str.charAt(0).toUpperCase()}${str.substr(1)}`;
+
+
+    if ((match = url.match(/img.shields.io\/codacy\/(.+)\/(.+)\/(.+).svg/))) {
+        data = { type: match[1], token: match[2], branch: match[3] };
+    } else if ((match = url.match(/img.shields.io\/codacy\/(.+)\/(.+).svg/))) {
+        data = { type: match[1], token: match[2] };
+    } else if ((match = url.match(/api.codacy.com\/project\/badge\/(.+)\/(.+)/))) {
+        data = { type: match[1].toLowerCase(), token: match[2], branch: parsedUrl.query.branch };
+    } else {
+        return null;
+    }
+
+    const codacyUrl = `https://api.codacy.com/project/badge/${upperCaseFirstLetter(data.type)}/${data.token}${data.branch ? `?branch=${data.branch}` : ''}`;
+    const shieldsUrl =
+        `https://img.shields.io/codacy/${data.type}/${data.token}${data.branch ? `/${data.branch}` : ''}`;
+
+    return {
+        urls: {
+            original: parsedUrl.href,
+            service: codacyUrl,
+            shields: `${shieldsUrl}.svg`,
+            content: `${shieldsUrl}.json`,
+        },
+        info: {
+            service: 'codacy',
+            type: data.type,
+            modifiers: { branch: data.branch },
+        },
+    };
+};

--- a/lib/util/capitalize.js
+++ b/lib/util/capitalize.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = str => `${str.charAt(0).toUpperCase()}${str.substr(1)}`;

--- a/test/spec/codacy.js
+++ b/test/spec/codacy.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import detectBadges from '../../';
 
-test('codacy: codacy.com (grade)', t => {
+test('codacy: codacy.com (quality)', t => {
     const token = 'e27821fb6289410b8f58338c7e0bc686';
 
     const badge = detectBadges(`https://api.codacy.com/project/badge/Grade/${token}`)[0];
@@ -10,10 +10,10 @@ test('codacy: codacy.com (grade)', t => {
     t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}`);
     t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}.json`);
     t.is(badge.info.service, 'codacy');
-    t.is(badge.info.type, 'grade');
+    t.is(badge.info.type, 'quality');
 });
 
-test('codacy: codacy.com (grade with branch)', t => {
+test('codacy: codacy.com (quality with branch)', t => {
     const token = 'e27821fb6289410b8f58338c7e0bc686';
     const branch = 'master';
 
@@ -23,7 +23,7 @@ test('codacy: codacy.com (grade with branch)', t => {
     t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}`);
     t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}/${branch}.json`);
     t.is(badge.info.service, 'codacy');
-    t.is(badge.info.type, 'grade');
+    t.is(badge.info.type, 'quality');
     t.deepEqual(badge.info.modifiers, { branch: 'master' });
 });
 
@@ -53,7 +53,7 @@ test('codacy: codacy.com (coverage with branch)', t => {
     t.deepEqual(badge.info.modifiers, { branch: 'master' });
 });
 
-test('codacy: shields.io (grade)', t => {
+test('codacy: shields.io (quality)', t => {
     const token = 'e27821fb6289410b8f58338c7e0bc686';
 
     const badge = detectBadges(`https://img.shields.io/codacy/grade/${token}.svg`)[0];
@@ -62,10 +62,10 @@ test('codacy: shields.io (grade)', t => {
     t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}`);
     t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}.json`);
     t.is(badge.info.service, 'codacy');
-    t.is(badge.info.type, 'grade');
+    t.is(badge.info.type, 'quality');
 });
 
-test('codacy: shields.io (grade with branch)', t => {
+test('codacy: shields.io (quality with branch)', t => {
     const token = 'e27821fb6289410b8f58338c7e0bc686';
     const branch = 'master';
 
@@ -75,7 +75,7 @@ test('codacy: shields.io (grade with branch)', t => {
     t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}`);
     t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}/${branch}.json`);
     t.is(badge.info.service, 'codacy');
-    t.is(badge.info.type, 'grade');
+    t.is(badge.info.type, 'quality');
     t.deepEqual(badge.info.modifiers, { branch: 'master' });
 });
 

--- a/test/spec/codacy.js
+++ b/test/spec/codacy.js
@@ -1,0 +1,113 @@
+import test from 'ava';
+import detectBadges from '../../';
+
+test('codacy: codacy.com (grade)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+
+    const badge = detectBadges(`https://api.codacy.com/project/badge/Grade/${token}`)[0];
+
+    t.is(badge.urls.original, `https://api.codacy.com/project/badge/Grade/${token}`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'grade');
+});
+
+test('codacy: codacy.com (grade with branch)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}`)[0];
+
+    t.is(badge.urls.original, `https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}/${branch}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'grade');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codacy: codacy.com (coverage)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+
+    const badge = detectBadges(`https://api.codacy.com/project/badge/Coverage/${token}`)[0];
+
+    t.is(badge.urls.original, `https://api.codacy.com/project/badge/Coverage/${token}`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Coverage/${token}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/coverage/${token}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'coverage');
+});
+
+test('codacy: codacy.com (coverage with branch)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://api.codacy.com/project/badge/Coverage/${token}?branch=${branch}`)[0];
+
+    t.is(badge.urls.original, `https://api.codacy.com/project/badge/Coverage/${token}?branch=${branch}`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Coverage/${token}?branch=${branch}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/coverage/${token}/${branch}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'coverage');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codacy: shields.io (grade)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+
+    const badge = detectBadges(`https://img.shields.io/codacy/grade/${token}.svg`)[0];
+
+    t.is(badge.urls.original, `https://img.shields.io/codacy/grade/${token}.svg`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'grade');
+});
+
+test('codacy: shields.io (grade with branch)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://img.shields.io/codacy/grade/${token}/${branch}.svg`)[0];
+
+    t.is(badge.urls.original, `https://img.shields.io/codacy/grade/${token}/${branch}.svg`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Grade/${token}?branch=${branch}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/grade/${token}/${branch}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'grade');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codacy: shields.io (coverage)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+
+    const badge = detectBadges(`https://img.shields.io/codacy/coverage/${token}.svg`)[0];
+
+    t.is(badge.urls.original, `https://img.shields.io/codacy/coverage/${token}.svg`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Coverage/${token}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/coverage/${token}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'coverage');
+});
+
+test('codacy: shields.io (coverage with branch)', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://img.shields.io/codacy/coverage/${token}/${branch}.svg`)[0];
+
+    t.is(badge.urls.original, `https://img.shields.io/codacy/coverage/${token}/${branch}.svg`);
+    t.is(badge.urls.service, `https://api.codacy.com/project/badge/Coverage/${token}?branch=${branch}`);
+    t.is(badge.urls.content, `https://img.shields.io/codacy/coverage/${token}/${branch}.json`);
+    t.is(badge.info.service, 'codacy');
+    t.is(badge.info.type, 'coverage');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
+test('codacy: not a valid codacy url', t => {
+    const token = 'e27821fb6289410b8f58338c7e0bc686';
+
+    t.falsy(detectBadges(`https://api.codacy.org/project/badge/Grade/${token}`)[0]);
+    t.falsy(detectBadges(`https://api.codacy.org/project/badge/Coverage/${token}`)[0]);
+});

--- a/test/spec/readmeFiles.js
+++ b/test/spec/readmeFiles.js
@@ -191,7 +191,7 @@ test('readme files: purgecss', t => {
             shields: 'https://img.shields.io/codacy/grade/2f2f3fb0a5c541beab2018483e62a828.svg',
             content: 'https://img.shields.io/codacy/grade/2f2f3fb0a5c541beab2018483e62a828.json',
         },
-        info: { service: 'codacy', type: 'grade', modifiers: { branch: undefined } },
+        info: { service: 'codacy', type: 'quality', modifiers: { branch: undefined } },
     });
 
     t.deepEqual(badges[5], {

--- a/test/spec/readmeFiles.js
+++ b/test/spec/readmeFiles.js
@@ -184,7 +184,26 @@ test('readme files: purgecss', t => {
         },
         info: { service: 'david', type: 'dependencies', modifiers: { statusType: 'dev' } },
     });
+
     t.deepEqual(badges[4], {
+        urls: { original: 'https://api.codacy.com/project/badge/Grade/2f2f3fb0a5c541beab2018483e62a828',
+            service: 'https://api.codacy.com/project/badge/Grade/2f2f3fb0a5c541beab2018483e62a828',
+            shields: 'https://img.shields.io/codacy/grade/2f2f3fb0a5c541beab2018483e62a828.svg',
+            content: 'https://img.shields.io/codacy/grade/2f2f3fb0a5c541beab2018483e62a828.json',
+        },
+        info: { service: 'codacy', type: 'grade', modifiers: { branch: undefined } },
+    });
+
+    t.deepEqual(badges[5], {
+        urls: {
+            original: 'https://api.codacy.com/project/badge/Coverage/2f2f3fb0a5c541beab2018483e62a828',
+            service: 'https://api.codacy.com/project/badge/Coverage/2f2f3fb0a5c541beab2018483e62a828',
+            shields: 'https://img.shields.io/codacy/coverage/2f2f3fb0a5c541beab2018483e62a828.svg',
+            content: 'https://img.shields.io/codacy/coverage/2f2f3fb0a5c541beab2018483e62a828.json' },
+        info: { service: 'codacy', type: 'coverage', modifiers: { branch: undefined } },
+    });
+
+    t.deepEqual(badges[6], {
         urls: {
             original: 'https://img.shields.io/npm/v/purgecss.svg',
             shields: 'https://img.shields.io/npm/v/purgecss.svg',


### PR DESCRIPTION
## Proposed changes

Add codacy support:
- Code quality grade
- Code Coverage

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I am not sure about some of the changes that I made concerning the codacy badges. I put the name of the type for the code quality grade as `grade`. This seems to be how codacy reference it in their url. Shields.io seems to use `code quality`. Which one would be better?

Codacy has two badges: coverage and code quality. should the type be added to the modifiers object? or would it be repetitive with the `type` property?