### PR TITLE
fix(travis): Recognise travis-ci.com URLs

### DIFF
--- a/lib/travis.js
+++ b/lib/travis.js
@@ -8,18 +8,18 @@ module.exports = function (parsedUrl) {
     let match;
     let data;
 
-    if ((match = url.match(/img.shields.io\/travis\/(.+)\/(.+)\/(.+)\..+/))) {
+    if ((match = url.match(/travis-ci.(com|org)\/(.+)\/(.+)\..+/))) {
+        data = { user: match[2], repo: match[3], branch: parsedUrl.query.branch, site: match[1] };
+    } else if ((match = url.match(/img.shields.io\/travis\/(.+)\/(.+)\/(.+)\..+/))) {
         data = { user: match[1], repo: match[2], branch: match[3] };
     } else if ((match = url.match(/img.shields.io\/travis\/(.+)\/(.+)\..+/))) {
         data = { user: match[1], repo: match[2] };
-    } else if ((match = url.match(/travis-ci.org\/(.+)\/(.+)\..+/))) {
-        data = { user: match[1], repo: match[2], branch: parsedUrl.query.branch };
     } else {
         return null;
     }
 
     const travisUrl =
-        `https://api.travis-ci.org/${data.user}/${data.repo}.svg${data.branch ? `?branch=${data.branch}` : ''}`;
+        `https://api.travis-ci.${data.site || 'org'}/${data.user}/${data.repo}.svg${data.branch ? `?branch=${data.branch}` : ''}`;
     const shieldsUrl =
         `https://img.shields.io/travis/${data.user}/${data.repo}${data.branch ? `/${data.branch}` : ''}`;
 

--- a/test/spec/travis.js
+++ b/test/spec/travis.js
@@ -29,6 +29,21 @@ test('travis: travis-ci.org (with branch)', t => {
     t.deepEqual(badge.info.modifiers, { branch: 'master' });
 });
 
+test('travis: travis-ci.com (with branch)', t => {
+    const user = 'IndigoUnited';
+    const repo = 'js-promtie';
+    const branch = 'master';
+
+    const badge = detectBadges(`https://travis-ci.com/${user}/${repo}.svg?branch=${branch}`)[0];
+
+    t.is(badge.urls.original, `https://travis-ci.com/${user}/${repo}.svg?branch=${branch}`);
+    t.is(badge.urls.service, `https://api.travis-ci.com/${user}/${repo}.svg?branch=${branch}`);
+    t.is(badge.urls.content, `https://img.shields.io/travis/${user}/${repo}/${branch}.json`);
+    t.is(badge.info.service, 'travis');
+    t.is(badge.info.type, 'build');
+    t.deepEqual(badge.info.modifiers, { branch: 'master' });
+});
+
 test('travis: shields.io', t => {
     const user = 'IndigoUnited';
     const repo = 'js-promtie';


### PR DESCRIPTION
As the transition to travis-ci.com is nearing completion, the
legacy dot-org URLs are becoming more and more rare, which is
negatively affecting the package quality score on <https://npms.io/>

* Recognise travis-ci.com URLs.
* Recognise the site (org vs com) because otherwise the API URL that we return will not work as expected (they are different realms, not aliased!).
* Move the canonical URL detection higher up because it is important that we parse dot-org vs dot-com correctly if it is available.

I have left the default unchanged, which means it will continue to use `.org` by default if the badge only contains third-party (indirect) URLs. This should probably change in the future but kept as-is for now to make the commit uncontroversial.

Fixes https://github.com/IndigoUnited/node-detect-readme-badges/issues/56.